### PR TITLE
Refinance Updates

### DIFF
--- a/src/AstariaRouter.sol
+++ b/src/AstariaRouter.sol
@@ -109,14 +109,10 @@ contract AstariaRouter is
 
     s.liquidationFeeNumerator = uint32(130);
     s.liquidationFeeDenominator = uint32(1000);
-    s.minInterestBPS = uint32((uint256(1e15) * 5) / (365 days));
     s.minEpochLength = uint32(7 days);
     s.maxEpochLength = uint32(45 days);
     s.maxInterestRate = ((uint256(1e16) * 200) / (365 days)).safeCastTo88();
     //63419583966; // 200% apy / second
-    s.buyoutFeeNumerator = uint32(100);
-    s.buyoutFeeDenominator = uint32(1000);
-    s.minDurationIncrease = uint32(5 days);
     s.guardian = msg.sender;
   }
 
@@ -301,20 +297,6 @@ contract AstariaRouter is
       if (denominator < numerator) revert InvalidFileData();
       s.protocolFeeNumerator = numerator.safeCastTo32();
       s.protocolFeeDenominator = denominator.safeCastTo32();
-    } else if (what == FileType.BuyoutFee) {
-      (uint256 numerator, uint256 denominator) = abi.decode(
-        data,
-        (uint256, uint256)
-      );
-      if (denominator < numerator) revert InvalidFileData();
-      s.buyoutFeeNumerator = numerator.safeCastTo32();
-      s.buyoutFeeDenominator = denominator.safeCastTo32();
-    } else if (what == FileType.MinInterestBPS) {
-      uint256 value = abi.decode(data, (uint256));
-      s.minInterestBPS = value.safeCastTo32();
-    } else if (what == FileType.MinDurationIncrease) {
-      uint256 value = abi.decode(data, (uint256));
-      s.minDurationIncrease = value.safeCastTo32();
     } else if (what == FileType.MinEpochLength) {
       s.minEpochLength = abi.decode(data, (uint256)).safeCastTo32();
     } else if (what == FileType.MaxEpochLength) {
@@ -404,11 +386,10 @@ contract AstariaRouter is
     return s.auctionWindow + (includeBuffer ? s.auctionWindowBuffer : 0);
   }
 
-  function _sliceUint(bytes memory bs, uint256 start)
-    internal
-    pure
-    returns (uint256 x)
-  {
+  function _sliceUint(
+    bytes memory bs,
+    uint256 start
+  ) internal pure returns (uint256 x) {
     uint256 length = bs.length;
 
     assembly {
@@ -487,7 +468,9 @@ contract AstariaRouter is
     });
   }
 
-  function commitToLiens(IAstariaRouter.Commitment[] memory commitments)
+  function commitToLiens(
+    IAstariaRouter.Commitment[] memory commitments
+  )
     public
     whenNotPaused
     returns (uint256[] memory lienIds, ILienToken.Stack[] memory stack)
@@ -519,11 +502,10 @@ contract AstariaRouter is
       .safeTransfer(msg.sender, totalBorrowed);
   }
 
-  function newVault(address delegate, address underlying)
-    external
-    whenNotPaused
-    returns (address)
-  {
+  function newVault(
+    address delegate,
+    address underlying
+  ) external whenNotPaused returns (address) {
     address[] memory allowList = new address[](1);
     allowList[0] = msg.sender;
     RouterStorage storage s = _loadRouterSlot();
@@ -581,11 +563,7 @@ contract AstariaRouter is
     external
     whenNotPaused
     validVault(msg.sender)
-    returns (
-      uint256,
-      ILienToken.Stack[] memory,
-      uint256
-    )
+    returns (uint256, ILienToken.Stack[] memory, uint256)
   {
     RouterStorage storage s = _loadRouterSlot();
 
@@ -608,20 +586,18 @@ contract AstariaRouter is
       );
   }
 
-  function canLiquidate(ILienToken.Stack memory stack)
-    public
-    view
-    returns (bool)
-  {
+  function canLiquidate(
+    ILienToken.Stack memory stack
+  ) public view returns (bool) {
     RouterStorage storage s = _loadRouterSlot();
     return (stack.point.end <= block.timestamp ||
       msg.sender == s.COLLATERAL_TOKEN.ownerOf(stack.lien.collateralId));
   }
 
-  function liquidate(ILienToken.Stack[] memory stack, uint8 position)
-    public
-    returns (OrderParameters memory listedOrder)
-  {
+  function liquidate(
+    ILienToken.Stack[] memory stack,
+    uint8 position
+  ) public returns (OrderParameters memory listedOrder) {
     if (!canLiquidate(stack[position])) {
       revert InvalidLienState(LienState.HEALTHY);
     }
@@ -664,42 +640,8 @@ contract AstariaRouter is
       );
   }
 
-  function getBuyoutFee(uint256 remainingInterestIn)
-    external
-    view
-    returns (uint256)
-  {
-    RouterStorage storage s = _loadRouterSlot();
-    return
-      remainingInterestIn.mulDivDown(
-        s.buyoutFeeNumerator,
-        s.buyoutFeeDenominator
-      );
-  }
-
   function isValidVault(address vault) public view returns (bool) {
     return _loadRouterSlot().vaults[vault];
-  }
-
-  function isValidRefinance(
-    ILienToken.Lien calldata newLien,
-    uint8 position,
-    ILienToken.Stack[] calldata stack
-  ) public view returns (bool) {
-    RouterStorage storage s = _loadRouterSlot();
-    uint256 maxNewRate = uint256(stack[position].lien.details.rate) -
-      s.minInterestBPS;
-
-    if (newLien.collateralId != stack[0].lien.collateralId) {
-      revert InvalidRefinanceCollateral(newLien.collateralId);
-    }
-    return
-      (newLien.details.rate <= maxNewRate &&
-        newLien.details.duration + block.timestamp >=
-        stack[position].point.end) ||
-      (block.timestamp + newLien.details.duration - stack[position].point.end >=
-        s.minDurationIncrease &&
-        newLien.details.rate <= stack[position].lien.details.rate);
   }
 
   /**
@@ -763,11 +705,7 @@ contract AstariaRouter is
     IAstariaRouter.Commitment memory c
   )
     internal
-    returns (
-      uint256,
-      ILienToken.Stack[] memory stack,
-      uint256 payout
-    )
+    returns (uint256, ILienToken.Stack[] memory stack, uint256 payout)
   {
     uint256 collateralId = c.tokenContract.computeId(c.tokenId);
 

--- a/src/LienToken.sol
+++ b/src/LienToken.sol
@@ -671,7 +671,7 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     // so we reduce the buyout fee they pay to the original Vault by the interest rate the new Vault is charging on the loan.
     return
       tenthOfRemainingInterest -
-      (newLienDuration * newLienRate).mulWadDown(tenthOfRemainingInterest);
+      (newLienRate * newLienDuration).mulWadDown(tenthOfRemainingInterest);
   }
 
   function getBuyout(

--- a/src/LienToken.sol
+++ b/src/LienToken.sol
@@ -56,10 +56,10 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     _disableInitializers();
   }
 
-  function initialize(
-    Authority _AUTHORITY,
-    ITransferProxy _TRANSFER_PROXY
-  ) public initializer {
+  function initialize(Authority _AUTHORITY, ITransferProxy _TRANSFER_PROXY)
+    public
+    initializer
+  {
     __initAuth(msg.sender, address(_AUTHORITY));
     __initERC721("Astaria Lien Token", "ALT");
     LienStorage storage s = _loadLienStorageSlot();
@@ -111,9 +111,12 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     emit FileUpdated(what, data);
   }
 
-  function supportsInterface(
-    bytes4 interfaceId
-  ) public view override(ERC721, IERC165) returns (bool) {
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    override(ERC721, IERC165)
+    returns (bool)
+  {
     return
       interfaceId == type(ILienToken).interfaceId ||
       super.supportsInterface(interfaceId);
@@ -122,7 +125,8 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
   function isValidRefinance(
     Lien calldata newLien,
     uint8 position,
-    Stack[] calldata stack
+    Stack[] calldata stack,
+    uint256 buyoutFee
   ) public view returns (bool) {
     LienStorage storage s = _loadLienStorageSlot();
     uint256 maxNewRate = uint256(stack[position].lien.details.rate) -
@@ -141,12 +145,17 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
       s.minDurationIncrease &&
       newLien.details.rate <= stack[position].lien.details.rate);
 
-    return hasImprovedRate || hasImprovedDuration;
+    bool amountDifferenceCoversBuyoutFee = (newLien.details.maxAmount >
+      stack[position].lien.details.maxAmount) &&
+      (newLien.details.maxAmount - stack[position].lien.details.maxAmount >
+        buyoutFee);
+
+    return
+      (hasImprovedRate || hasImprovedDuration) &&
+      amountDifferenceCoversBuyoutFee;
   }
 
-  function buyoutLien(
-    ILienToken.LienActionBuyout calldata params
-  )
+  function buyoutLien(ILienToken.LienActionBuyout calldata params)
     external
     validateStack(params.encumber.lien.collateralId, params.encumber.stack)
     returns (Stack[] memory, Stack memory newStack)
@@ -165,27 +174,35 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     LienStorage storage s,
     ILienToken.LienActionBuyout calldata params
   ) internal returns (Stack[] memory newStack, Stack memory newLien) {
-    //the borrower shouldn't incur more debt from the buyout than they already owe
-    (, newLien) = _createLien(s, params.encumber);
-    if (
-      !isValidRefinance({
-        newLien: params.encumber.lien,
-        position: params.position,
-        stack: params.encumber.stack
-      })
-    ) {
-      revert InvalidRefinance();
-    }
-
     if (
       s.collateralStateHash[params.encumber.lien.collateralId] == ACTIVE_AUCTION
     ) {
       revert InvalidState(InvalidStates.COLLATERAL_AUCTION);
     }
+
+    //the borrower shouldn't incur more debt from the buyout than they already owe
+    (, newLien) = _createLien(s, params.encumber);
+    uint256 buyoutFee = getBuyoutFee(
+      _getRemainingInterest(s, params.encumber.stack[params.position]),
+      newLien.lien.details.rate,
+      newLien.lien.details.duration
+    );
     (uint256 owed, uint256 buyout) = _getBuyout(
       s,
-      params.encumber.stack[params.position]
+      params.encumber.stack[params.position],
+      buyoutFee
     );
+
+    if (
+      !isValidRefinance({
+        newLien: params.encumber.lien,
+        position: params.position,
+        stack: params.encumber.stack,
+        buyoutFee: buyoutFee
+      })
+    ) {
+      revert InvalidRefinance();
+    }
 
     if (params.encumber.lien.details.maxAmount < owed) {
       revert InvalidBuyoutDetails(params.encumber.lien.details.maxAmount, owed);
@@ -245,27 +262,12 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
       newLien,
       params.encumber.stack[params.position].point.lienId
     );
-    uint256 maxPotentialDebt;
-    //    uint256 n = newStack.length;
-    uint256 i;
-    for (i; i < newStack.length; ) {
-      maxPotentialDebt += _getOwed(newStack[i], newStack[i].point.end);
-      //no need to check validity before the position we're buying
-      if (i == params.position) {
-        if (maxPotentialDebt > params.encumber.lien.details.maxPotentialDebt) {
-          revert InvalidState(InvalidStates.DEBT_LIMIT);
-        }
-      }
-      if (
-        i > params.position &&
-        (maxPotentialDebt > newStack[i].lien.details.maxPotentialDebt)
-      ) {
-        revert InvalidState(InvalidStates.DEBT_LIMIT);
-      }
-      unchecked {
-        ++i;
-      }
-    }
+
+    _validateNewLienAgainstDebtLimit(
+      newStack,
+      params.encumber.lien.details.maxPotentialDebt,
+      params.position
+    );
 
     // update target PublicVault state
     if (_isPublicVault(s, msg.sender)) {
@@ -281,6 +283,33 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     s.collateralStateHash[params.encumber.lien.collateralId] = keccak256(
       abi.encode(newStack)
     );
+  }
+
+  function _validateNewLienAgainstDebtLimit(
+    Stack[] memory newStack,
+    uint256 newMaxPotentialDebt,
+    uint8 position
+  ) internal {
+    uint256 maxPotentialDebt;
+    uint256 i;
+    for (i; i < newStack.length; ) {
+      maxPotentialDebt += _getOwed(newStack[i], newStack[i].point.end);
+      //no need to check validity before the position we're buying
+      if (i == position) {
+        if (maxPotentialDebt > newMaxPotentialDebt) {
+          revert InvalidState(InvalidStates.DEBT_LIMIT);
+        }
+      }
+      if (
+        i > position &&
+        (maxPotentialDebt > newStack[i].lien.details.maxPotentialDebt)
+      ) {
+        revert InvalidState(InvalidStates.DEBT_LIMIT);
+      }
+      unchecked {
+        ++i;
+      }
+    }
   }
 
   function _replaceStackAtPositionWithNewLien(
@@ -305,10 +334,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
    * @param stack The Lien for the loan to calculate interest for.
    * @param timestamp The timestamp at which to compute interest for.
    */
-  function _getInterest(
-    Stack memory stack,
-    uint256 timestamp
-  ) internal pure returns (uint256) {
+  function _getInterest(Stack memory stack, uint256 timestamp)
+    internal
+    pure
+    returns (uint256)
+  {
     uint256 delta_t = timestamp - stack.point.last;
 
     return (delta_t * stack.lien.details.rate).mulWadDown(stack.point.amount);
@@ -397,9 +427,12 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     );
   }
 
-  function tokenURI(
-    uint256 tokenId
-  ) public view override(ERC721, IERC721) returns (string memory) {
+  function tokenURI(uint256 tokenId)
+    public
+    view
+    override(ERC721, IERC721)
+    returns (string memory)
+  {
     if (!_exists(tokenId)) {
       revert InvalidTokenId(tokenId);
     }
@@ -435,13 +468,15 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     return _loadERC721Slot()._ownerOf[tokenId] != address(0);
   }
 
-  function createLien(
-    ILienToken.LienActionEncumber memory params
-  )
+  function createLien(ILienToken.LienActionEncumber memory params)
     external
     requiresAuth
     validateStack(params.lien.collateralId, params.stack)
-    returns (uint256 lienId, Stack[] memory newStack, uint256 lienSlope)
+    returns (
+      uint256 lienId,
+      Stack[] memory newStack,
+      uint256 lienSlope
+    )
   {
     LienStorage storage s = _loadLienStorageSlot();
     //0 - 4 are valid
@@ -575,24 +610,30 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     }
   }
 
-  function getAuctionData(
-    uint256 collateralId
-  ) external view returns (AuctionData memory) {
+  function getAuctionData(uint256 collateralId)
+    external
+    view
+    returns (AuctionData memory)
+  {
     return _loadLienStorageSlot().auctionData[collateralId];
   }
 
-  function getAuctionLiquidator(
-    uint256 collateralId
-  ) external view returns (address liquidator) {
+  function getAuctionLiquidator(uint256 collateralId)
+    external
+    view
+    returns (address liquidator)
+  {
     liquidator = _loadLienStorageSlot().auctionData[collateralId].liquidator;
     if (liquidator == address(0)) {
       revert InvalidState(InvalidStates.COLLATERAL_NOT_LIQUIDATED);
     }
   }
 
-  function getAmountOwingAtLiquidation(
-    ILienToken.Stack calldata stack
-  ) public view returns (uint256) {
+  function getAmountOwingAtLiquidation(ILienToken.Stack calldata stack)
+    public
+    view
+    returns (uint256)
+  {
     return
       _loadLienStorageSlot()
         .auctionData[stack.lien.collateralId]
@@ -607,35 +648,58 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     }
   }
 
-  function getCollateralState(
-    uint256 collateralId
-  ) external view returns (bytes32) {
+  function getCollateralState(uint256 collateralId)
+    external
+    view
+    returns (bytes32)
+  {
     return _loadLienStorageSlot().collateralStateHash[collateralId];
   }
 
   function getBuyoutFee(
-    uint256 remainingInterestIn
+    uint256 remainingInterestIn,
+    uint256 newLienRate,
+    uint256 newLienDuration
   ) public view returns (uint256) {
     LienStorage storage s = _loadLienStorageSlot();
+    uint256 tenthOfRemainingInterest = remainingInterestIn.mulDivDown(
+      s.buyoutFeeNumerator,
+      s.buyoutFeeDenominator
+    );
+
+    // We don't want Vaults receiving a refinance to lose out on potential interest (vs. having accepted a new loan),
+    // so we reduce the buyout fee they pay to the original Vault by the interest rate the new Vault is charging on the loan.
     return
-      remainingInterestIn.mulDivDown(
-        s.buyoutFeeNumerator,
-        s.buyoutFeeDenominator
-      );
+      tenthOfRemainingInterest -
+      (newLienDuration * newLienRate).mulWadDown(tenthOfRemainingInterest);
   }
 
   function getBuyout(
-    Stack calldata stack
+    Stack calldata stack,
+    uint256 newLienRate,
+    uint256 newLienDuration
   ) public view returns (uint256 owed, uint256 buyout) {
-    return _getBuyout(_loadLienStorageSlot(), stack);
+    LienStorage storage s = _loadLienStorageSlot();
+    return
+      _getBuyout(
+        s,
+        stack,
+        getBuyoutFee(
+          _getRemainingInterest(s, stack),
+          newLienRate,
+          newLienDuration
+        )
+      );
   }
 
   function _getBuyout(
     LienStorage storage s,
-    Stack calldata stack
+    Stack calldata stack,
+    uint256 buyoutFee
   ) internal view returns (uint256 owed, uint256 buyout) {
     owed = _getOwed(stack, block.timestamp);
-    buyout = owed + getBuyoutFee(_getRemainingInterest(s, stack));
+    buyout = owed + buyoutFee;
+    //    + getBuyoutFee(_getRemainingInterest(s, stack));
   }
 
   function makePayment(
@@ -748,9 +812,7 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     return stack.lien.details.rate.mulWadDown(stack.point.amount);
   }
 
-  function getMaxPotentialDebtForCollateral(
-    Stack[] memory stack
-  )
+  function getMaxPotentialDebtForCollateral(Stack[] memory stack)
     public
     view
     validateStack(stack[0].lien.collateralId, stack)
@@ -771,10 +833,7 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     }
   }
 
-  function getMaxPotentialDebtForCollateral(
-    Stack[] memory stack,
-    uint256 end
-  )
+  function getMaxPotentialDebtForCollateral(Stack[] memory stack, uint256 end)
     public
     view
     validateStack(stack[0].lien.collateralId, stack)
@@ -794,10 +853,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     return _getOwed(stack, block.timestamp);
   }
 
-  function getOwed(
-    Stack memory stack,
-    uint256 timestamp
-  ) external view returns (uint88) {
+  function getOwed(Stack memory stack, uint256 timestamp)
+    external
+    view
+    returns (uint88)
+  {
     validateLien(stack.lien);
     return _getOwed(stack, timestamp);
   }
@@ -807,10 +867,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
    * @param stack The specified Lien.
    * @return The amount owed to the Lien at the specified timestamp.
    */
-  function _getOwed(
-    Stack memory stack,
-    uint256 timestamp
-  ) internal pure returns (uint88) {
+  function _getOwed(Stack memory stack, uint256 timestamp)
+    internal
+    pure
+    returns (uint88)
+  {
     return stack.point.amount + _getInterest(stack, timestamp).safeCastTo88();
   }
 
@@ -820,10 +881,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
    * @param stack the lien
    * @return The WETH still owed in interest to the Lien.
    */
-  function _getRemainingInterest(
-    LienStorage storage s,
-    Stack memory stack
-  ) internal view returns (uint256) {
+  function _getRemainingInterest(LienStorage storage s, Stack memory stack)
+    internal
+    view
+    returns (uint256)
+  {
     uint256 delta_t = stack.point.end - block.timestamp;
     return (delta_t * stack.lien.details.rate).mulWadDown(stack.point.amount);
   }
@@ -899,10 +961,10 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     return (activeStack, amount);
   }
 
-  function _removeStackPosition(
-    Stack[] memory stack,
-    uint8 position
-  ) internal returns (Stack[] memory newStack) {
+  function _removeStackPosition(Stack[] memory stack, uint8 position)
+    internal
+    returns (Stack[] memory newStack)
+  {
     uint256 length = stack.length;
     require(position < length);
     newStack = new ILienToken.Stack[](length - 1);
@@ -927,10 +989,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     );
   }
 
-  function _isPublicVault(
-    LienStorage storage s,
-    address account
-  ) internal view returns (bool) {
+  function _isPublicVault(LienStorage storage s, address account)
+    internal
+    view
+    returns (bool)
+  {
     return
       s.ASTARIA_ROUTER.isValidVault(account) &&
       IPublicVault(account).supportsInterface(type(IPublicVault).interfaceId);
@@ -943,10 +1006,11 @@ contract LienToken is ERC721, ILienToken, AuthInitializable {
     return _getPayee(_loadLienStorageSlot(), lienId);
   }
 
-  function _getPayee(
-    LienStorage storage s,
-    uint256 lienId
-  ) internal view returns (address) {
+  function _getPayee(LienStorage storage s, uint256 lienId)
+    internal
+    view
+    returns (address)
+  {
     return
       s.lienMeta[lienId].payee != address(0)
         ? s.lienMeta[lienId].payee

--- a/src/interfaces/IAstariaRouter.sol
+++ b/src/interfaces/IAstariaRouter.sol
@@ -31,13 +31,10 @@ interface IAstariaRouter is IPausable, IBeacon {
     LiquidationFee,
     ProtocolFee,
     StrategistFee,
-    MinInterestBPS,
     MinEpochLength,
     MaxEpochLength,
     MinInterestRate,
     MaxInterestRate,
-    BuyoutFee,
-    MinDurationIncrease,
     AuctionWindow,
     StrategyValidator,
     Implementation,
@@ -71,13 +68,9 @@ interface IAstariaRouter is IPausable, IBeacon {
     address feeTo; //20
     address BEACON_PROXY_IMPLEMENTATION; //20
     uint88 maxInterestRate; //6
-    uint32 minInterestBPS; // was uint64
     //slot 3 +
     address guardian; //20
     address newGuardian; //20
-    uint32 buyoutFeeNumerator;
-    uint32 buyoutFeeDenominator;
-    uint32 minDurationIncrease;
     mapping(uint8 => address) strategyValidators;
     mapping(uint8 => address) implementations;
     //A strategist can have many deployed vaults
@@ -162,9 +155,10 @@ interface IAstariaRouter is IPausable, IBeacon {
    * @param underlying The address of the underlying token.
    * @return The address of the new PrivateVault.
    */
-  function newVault(address delegate, address underlying)
-    external
-    returns (address);
+  function newVault(
+    address delegate,
+    address underlying
+  ) external returns (address);
 
   /**
    * @notice Retrieves the address that collects protocol-level fees.
@@ -176,9 +170,9 @@ interface IAstariaRouter is IPausable, IBeacon {
    * @param commitments The commitment proofs and requested loan data for each loan.
    * @return lienIds the lienIds for each loan.
    */
-  function commitToLiens(Commitment[] memory commitments)
-    external
-    returns (uint256[] memory, ILienToken.Stack[] memory);
+  function commitToLiens(
+    Commitment[] memory commitments
+  ) external returns (uint256[] memory, ILienToken.Stack[] memory);
 
   /**
    * @notice Create a new lien against a CollateralToken.
@@ -188,13 +182,7 @@ interface IAstariaRouter is IPausable, IBeacon {
   function requestLienPosition(
     IAstariaRouter.Commitment calldata params,
     address recipient
-  )
-    external
-    returns (
-      uint256,
-      ILienToken.Stack[] memory,
-      uint256
-    );
+  ) external returns (uint256, ILienToken.Stack[] memory, uint256);
 
   function LIEN_TOKEN() external view returns (ILienToken);
 
@@ -216,11 +204,6 @@ interface IAstariaRouter is IPausable, IBeacon {
   function getProtocolFee(uint256) external view returns (uint256);
 
   /**
-   * @notice Computes the fee Vaults earn when a Lien is bought out using the buyoutFee numerator and denominator.
-   */
-  function getBuyoutFee(uint256) external view returns (uint256);
-
-  /**
    * @notice Computes the fee the users earn on liquidating an expired lien from the liquidationFee numerator and denominator.
    */
   function getLiquidatorFee(uint256) external view returns (uint256);
@@ -231,9 +214,10 @@ interface IAstariaRouter is IPausable, IBeacon {
    * @param position The position of the defaulted lien.
    * @return reserve The amount owed on all liens for against the collateral being liquidated, including accrued interest.
    */
-  function liquidate(ILienToken.Stack[] calldata stack, uint8 position)
-    external
-    returns (OrderParameters memory);
+  function liquidate(
+    ILienToken.Stack[] calldata stack,
+    uint8 position
+  ) external returns (OrderParameters memory);
 
   /**
    * @notice Returns whether a specified lien can be liquidated.
@@ -277,20 +261,6 @@ interface IAstariaRouter is IPausable, IBeacon {
    */
   function getImpl(uint8 implType) external view returns (address impl);
 
-  /**
-   * @notice Returns whether a new lien offers more favorable terms over an old lien.
-   * A new lien must have a rate less than or equal to maxNewRate,
-   * or a duration lower by minDurationIncrease, provided the other parameter does not get any worse.
-   * @param newLien The new Lien for the proposed refinance.
-   * @param position The Lien position against the CollateralToken.
-   * @param stack The Stack of existing Liens against the CollateralToken.
-   */
-  function isValidRefinance(
-    ILienToken.Lien calldata newLien,
-    uint8 position,
-    ILienToken.Stack[] calldata stack
-  ) external view returns (bool);
-
   event Liquidation(uint256 collateralId, uint256 position);
   event NewVault(
     address strategist,
@@ -303,7 +273,6 @@ interface IAstariaRouter is IPausable, IBeacon {
   error InvalidEpochLength(uint256);
   error InvalidRefinanceRate(uint256);
   error InvalidRefinanceDuration(uint256);
-  error InvalidRefinanceCollateral(uint256);
   error InvalidVaultState(VaultState);
   error InvalidSenderForCollateral(address, uint256);
   error InvalidLienState(LienState);

--- a/src/interfaces/ILienToken.sol
+++ b/src/interfaces/ILienToken.sol
@@ -102,9 +102,10 @@ interface ILienToken is IERC721 {
    * @param lien The Lien.
    * @return lienId The lienId of the requested Lien, if valid (otherwise, reverts).
    */
-  function validateLien(
-    Lien calldata lien
-  ) external view returns (uint256 lienId);
+  function validateLien(Lien calldata lien)
+    external
+    view
+    returns (uint256 lienId);
 
   function ASTARIA_ROUTER() external view returns (IAstariaRouter);
 
@@ -115,9 +116,10 @@ interface ILienToken is IERC721 {
    * @param stack The Lien to compute the slope for.
    * @return slope The rate for the specified lien, in WETH per second.
    */
-  function calculateSlope(
-    Stack calldata stack
-  ) external pure returns (uint256 slope);
+  function calculateSlope(Stack calldata stack)
+    external
+    pure
+    returns (uint256 slope);
 
   /**
    * @notice Stops accruing interest for all liens against a single CollateralToken.
@@ -132,15 +134,26 @@ interface ILienToken is IERC721 {
 
   /**
    * @notice Computes the fee Vaults earn when a Lien is bought out using the buyoutFee numerator and denominator.
+   * @param remainingInterestIn The remaining interest owed on the Lien, used to calculate the buyout fee paid by the Vault receiving the buyout.
+   * @param newLienRate The interest rate of the new Lien. Used with newLienDuration to discount the buyout fee by the interest the Vault would have earned on a new Lien.
+   * @param newLienDuration The duration of the new Lien.
    */
-  function getBuyoutFee(uint256) external view returns (uint256);
+  function getBuyoutFee(
+    uint256 remainingInterestIn,
+    uint256 newLienRate,
+    uint256 newLienDuration
+  ) external view returns (uint256);
 
   /**
    * @notice Computes and returns the buyout amount for a Lien.
    * @param stack the lien
+   * @param newLienRate The interest rate of the new Lien. Used with newLienDuration to discount the buyout fee by the interest the Vault would have earned on a new Lien.
+   * @param newLienDuration The duration of the new Lien.
    */
   function getBuyout(
-    Stack calldata stack
+    Stack calldata stack,
+    uint256 newLienRate,
+    uint256 newLienDuration
   ) external view returns (uint256 owed, uint256 buyout);
 
   /**
@@ -156,10 +169,10 @@ interface ILienToken is IERC721 {
    * @param timestamp the timestamp you want to inquire about
    * @return the amount owed in uint192
    */
-  function getOwed(
-    Stack calldata stack,
-    uint256 timestamp
-  ) external view returns (uint88);
+  function getOwed(Stack calldata stack, uint256 timestamp)
+    external
+    view
+    returns (uint88);
 
   /**
    * @notice Public view function that computes the interest for a LienToken since its last payment.
@@ -171,25 +184,31 @@ interface ILienToken is IERC721 {
    * @notice Retrieves a lienCount for specific collateral
    * @param collateralId the Lien to compute a point for
    */
-  function getCollateralState(
-    uint256 collateralId
-  ) external view returns (bytes32);
+  function getCollateralState(uint256 collateralId)
+    external
+    view
+    returns (bytes32);
 
   /**
    * @notice Retrieves a specific point by its lienId.
    * @param stack the Lien to compute a point for
    */
-  function getAmountOwingAtLiquidation(
-    ILienToken.Stack calldata stack
-  ) external view returns (uint256);
+  function getAmountOwingAtLiquidation(ILienToken.Stack calldata stack)
+    external
+    view
+    returns (uint256);
 
   /**
    * @notice Creates a new lien against a CollateralToken.
    * @param params LienActionEncumber data containing CollateralToken information and lien parameters (rate, duration, and amount, rate, and debt caps).
    */
-  function createLien(
-    LienActionEncumber memory params
-  ) external returns (uint256 lienId, Stack[] memory stack, uint256 slope);
+  function createLien(LienActionEncumber memory params)
+    external
+    returns (
+      uint256 lienId,
+      Stack[] memory stack,
+      uint256 slope
+    );
 
   /**
    * @notice Returns whether a new lien offers more favorable terms over an old lien.
@@ -202,16 +221,17 @@ interface ILienToken is IERC721 {
   function isValidRefinance(
     Lien calldata newLien,
     uint8 position,
-    Stack[] calldata stack
+    Stack[] calldata stack,
+    uint256 buyoutFee
   ) external view returns (bool);
 
   /**
    * @notice Purchase a LienToken for its buyout price.
    * @param params The LienActionBuyout data specifying the lien position, receiver address, and underlying CollateralToken information of the lien.
    */
-  function buyoutLien(
-    LienActionBuyout memory params
-  ) external returns (Stack[] memory, Stack memory);
+  function buyoutLien(LienActionBuyout memory params)
+    external
+    returns (Stack[] memory, Stack memory);
 
   /**
    * @notice Called by the ClearingHouse (through Seaport) to pay back debt with auction funds.
@@ -262,25 +282,28 @@ interface ILienToken is IERC721 {
    * @notice Retrieves the AuctionData for a CollateralToken (The liquidator address and the AuctionStack).
    * @param collateralId The ID of the CollateralToken.
    */
-  function getAuctionData(
-    uint256 collateralId
-  ) external view returns (AuctionData memory);
+  function getAuctionData(uint256 collateralId)
+    external
+    view
+    returns (AuctionData memory);
 
   /**
    * @notice Retrieves the liquidator for a CollateralToken.
    * @param collateralId The ID of the CollateralToken.
    */
-  function getAuctionLiquidator(
-    uint256 collateralId
-  ) external view returns (address liquidator);
+  function getAuctionLiquidator(uint256 collateralId)
+    external
+    view
+    returns (address liquidator);
 
   /**
    * Calculates the debt accrued by all liens against a CollateralToken, assuming no payments are made until the end timestamp in the stack.
    * @param stack The stack data for active liens against the CollateralToken.
    */
-  function getMaxPotentialDebtForCollateral(
-    ILienToken.Stack[] memory stack
-  ) external view returns (uint256);
+  function getMaxPotentialDebtForCollateral(ILienToken.Stack[] memory stack)
+    external
+    view
+    returns (uint256);
 
   /**
    * Calculates the debt accrued by all liens against a CollateralToken, assuming no payments are made until the provided timestamp.

--- a/src/interfaces/ILienToken.sol
+++ b/src/interfaces/ILienToken.sol
@@ -23,7 +23,10 @@ interface ILienToken is IERC721 {
   enum FileType {
     NotSupported,
     CollateralToken,
-    AstariaRouter
+    AstariaRouter,
+    BuyoutFee,
+    MinInterestBPS,
+    MinDurationIncrease
   }
 
   struct File {
@@ -42,6 +45,10 @@ interface ILienToken is IERC721 {
     mapping(uint256 => bytes32) collateralStateHash;
     mapping(uint256 => AuctionData) auctionData;
     mapping(uint256 => LienMeta) lienMeta;
+    uint32 buyoutFeeNumerator;
+    uint32 buyoutFeeDenominator;
+    uint32 minDurationIncrease;
+    uint32 minInterestBPS;
   }
 
   struct LienMeta {
@@ -95,10 +102,9 @@ interface ILienToken is IERC721 {
    * @param lien The Lien.
    * @return lienId The lienId of the requested Lien, if valid (otherwise, reverts).
    */
-  function validateLien(Lien calldata lien)
-    external
-    view
-    returns (uint256 lienId);
+  function validateLien(
+    Lien calldata lien
+  ) external view returns (uint256 lienId);
 
   function ASTARIA_ROUTER() external view returns (IAstariaRouter);
 
@@ -109,10 +115,9 @@ interface ILienToken is IERC721 {
    * @param stack The Lien to compute the slope for.
    * @return slope The rate for the specified lien, in WETH per second.
    */
-  function calculateSlope(Stack calldata stack)
-    external
-    pure
-    returns (uint256 slope);
+  function calculateSlope(
+    Stack calldata stack
+  ) external pure returns (uint256 slope);
 
   /**
    * @notice Stops accruing interest for all liens against a single CollateralToken.
@@ -126,13 +131,17 @@ interface ILienToken is IERC721 {
   ) external;
 
   /**
+   * @notice Computes the fee Vaults earn when a Lien is bought out using the buyoutFee numerator and denominator.
+   */
+  function getBuyoutFee(uint256) external view returns (uint256);
+
+  /**
    * @notice Computes and returns the buyout amount for a Lien.
    * @param stack the lien
    */
-  function getBuyout(Stack calldata stack)
-    external
-    view
-    returns (uint256 owed, uint256 buyout);
+  function getBuyout(
+    Stack calldata stack
+  ) external view returns (uint256 owed, uint256 buyout);
 
   /**
    * @notice Removes all liens for a given CollateralToken.
@@ -147,10 +156,10 @@ interface ILienToken is IERC721 {
    * @param timestamp the timestamp you want to inquire about
    * @return the amount owed in uint192
    */
-  function getOwed(Stack calldata stack, uint256 timestamp)
-    external
-    view
-    returns (uint88);
+  function getOwed(
+    Stack calldata stack,
+    uint256 timestamp
+  ) external view returns (uint88);
 
   /**
    * @notice Public view function that computes the interest for a LienToken since its last payment.
@@ -162,39 +171,47 @@ interface ILienToken is IERC721 {
    * @notice Retrieves a lienCount for specific collateral
    * @param collateralId the Lien to compute a point for
    */
-  function getCollateralState(uint256 collateralId)
-    external
-    view
-    returns (bytes32);
+  function getCollateralState(
+    uint256 collateralId
+  ) external view returns (bytes32);
 
   /**
    * @notice Retrieves a specific point by its lienId.
    * @param stack the Lien to compute a point for
    */
-  function getAmountOwingAtLiquidation(ILienToken.Stack calldata stack)
-    external
-    view
-    returns (uint256);
+  function getAmountOwingAtLiquidation(
+    ILienToken.Stack calldata stack
+  ) external view returns (uint256);
 
   /**
    * @notice Creates a new lien against a CollateralToken.
    * @param params LienActionEncumber data containing CollateralToken information and lien parameters (rate, duration, and amount, rate, and debt caps).
    */
-  function createLien(LienActionEncumber memory params)
-    external
-    returns (
-      uint256 lienId,
-      Stack[] memory stack,
-      uint256 slope
-    );
+  function createLien(
+    LienActionEncumber memory params
+  ) external returns (uint256 lienId, Stack[] memory stack, uint256 slope);
+
+  /**
+   * @notice Returns whether a new lien offers more favorable terms over an old lien.
+   * A new lien must have a rate less than or equal to maxNewRate,
+   * or a duration lower by minDurationIncrease, provided the other parameter does not get any worse.
+   * @param newLien The new Lien for the proposed refinance.
+   * @param position The Lien position against the CollateralToken.
+   * @param stack The Stack of existing Liens against the CollateralToken.
+   */
+  function isValidRefinance(
+    Lien calldata newLien,
+    uint8 position,
+    Stack[] calldata stack
+  ) external view returns (bool);
 
   /**
    * @notice Purchase a LienToken for its buyout price.
    * @param params The LienActionBuyout data specifying the lien position, receiver address, and underlying CollateralToken information of the lien.
    */
-  function buyoutLien(LienActionBuyout memory params)
-    external
-    returns (Stack[] memory, Stack memory);
+  function buyoutLien(
+    LienActionBuyout memory params
+  ) external returns (Stack[] memory, Stack memory);
 
   /**
    * @notice Called by the ClearingHouse (through Seaport) to pay back debt with auction funds.
@@ -245,28 +262,25 @@ interface ILienToken is IERC721 {
    * @notice Retrieves the AuctionData for a CollateralToken (The liquidator address and the AuctionStack).
    * @param collateralId The ID of the CollateralToken.
    */
-  function getAuctionData(uint256 collateralId)
-    external
-    view
-    returns (AuctionData memory);
+  function getAuctionData(
+    uint256 collateralId
+  ) external view returns (AuctionData memory);
 
   /**
    * @notice Retrieves the liquidator for a CollateralToken.
    * @param collateralId The ID of the CollateralToken.
    */
-  function getAuctionLiquidator(uint256 collateralId)
-    external
-    view
-    returns (address liquidator);
+  function getAuctionLiquidator(
+    uint256 collateralId
+  ) external view returns (address liquidator);
 
   /**
    * Calculates the debt accrued by all liens against a CollateralToken, assuming no payments are made until the end timestamp in the stack.
    * @param stack The stack data for active liens against the CollateralToken.
    */
-  function getMaxPotentialDebtForCollateral(ILienToken.Stack[] memory stack)
-    external
-    view
-    returns (uint256);
+  function getMaxPotentialDebtForCollateral(
+    ILienToken.Stack[] memory stack
+  ) external view returns (uint256);
 
   /**
    * Calculates the debt accrued by all liens against a CollateralToken, assuming no payments are made until the provided timestamp.
@@ -314,11 +328,13 @@ interface ILienToken is IERC721 {
   event BuyoutLien(address indexed buyer, uint256 lienId, uint256 buyout);
   event PayeeChanged(uint256 indexed lienId, address indexed payee);
 
+  error InvalidFileData();
   error UnsupportedFile();
   error InvalidTokenId(uint256 tokenId);
   error InvalidBuyoutDetails(uint256 lienMaxAmount, uint256 owed);
   error InvalidTerms();
   error InvalidRefinance();
+  error InvalidRefinanceCollateral(uint256);
   error InvalidLoanState();
   error InvalidSender();
   enum InvalidStates {

--- a/src/interfaces/IPublicVault.sol
+++ b/src/interfaces/IPublicVault.sol
@@ -42,7 +42,7 @@ interface IPublicVault is IVaultImplementation {
   struct BuyoutLienParams {
     uint256 lienSlope;
     uint256 lienEnd;
-    uint256 increaseYIntercept;
+    uint256 yInterceptChange;
   }
 
   struct AfterLiquidationParams {
@@ -134,10 +134,16 @@ interface IPublicVault is IVaultImplementation {
   function decreaseYIntercept(uint256 amount) external;
 
   /**
-   * Hook to update the PublicVault's slope, YIntercept, and last timestamp on a LienToken buyout.
-   * @param params The lien buyout parameters (lienSlope, lienEnd, and increaseYIntercept)
+   * Hook to update the PublicVault's slope, YIntercept, and last timestamp when a LienToken is bought out. Also decreases the active lien count for the lien's expiring epoch.
+   * @param params The lien buyout parameters (lienSlope, lienEnd, and yInterceptChange)
    */
-  function handleBuyoutLien(BuyoutLienParams calldata params) external;
+  function handleLoseLienToBuyout(BuyoutLienParams calldata params) external;
+
+  /**
+   * Hook to update the PublicVault's slope, YIntercept, and last timestamp when it receives a refinanced increase. Also decreases the active lien count for the lien's expiring epoch.
+   * @param params The lien buyout parameters (lienSlope, lienEnd, and yInterceptChange)
+   */
+  function handleReceiveBuyout(BuyoutLienParams calldata params) external;
 
   /**
    * Hook to update the PublicVault owner of a LienToken when it is sent to liquidation.

--- a/src/test/TestHelpers.t.sol
+++ b/src/test/TestHelpers.t.sol
@@ -189,10 +189,10 @@ contract TestHelpers is Deploy, ConsiderationTester {
 
   ILienToken.Details public refinanceLienDetails =
     ILienToken.Details({
-      maxAmount: 50 ether,
+      maxAmount: 51 ether,
       rate: (uint256(1e16) * 150) / (365 days),
       duration: 25 days,
-      maxPotentialDebt: 53 ether,
+      maxPotentialDebt: 200 ether,
       liquidationInitialAsk: 500 ether
     });
   ILienToken.Details public refinanceLienDetails2 =


### PR DESCRIPTION
Two updates to the refinance/buyout flow.

State changes:
If a PublicVault received a Lien from a refinance, its accounting (slope, last, yIntercept, and liensOpenForEpoch) were not updated. A new refinance hook, `PublicVault.handleReceiveBuyout()`, was added, similar to `PublicVault.handleBuyoutLien`, which is renamed to `handleLoseLienToBuyout` for clarity.

New refinance fee structure:
The old fee structure compensated Vaults for losing Liens to a buyout by having the new "target" Vault pay the old Vault 10% of the remaining interest on the loan. This introduced an attack vector where anyone could set up a Vault and issue a loan with interest up to maxInterestRate then refinance the loan towards any other Vault, draining the target Vault with the buyout fee. The new fee structure instead discounts the buyout fee by the interest rate the Vault could have earned on that fee throughout the loan duration. This means that the maxAmount of the new loan terms must be greater than the original loan amount by this difference: if the interest the target Vault would have earned issuing a loan worth only the fee amount is greater than the difference in amounts between the two Liens, then the refinance will be blocked.

Since we do not store the initial loan amount in storage, we make the conservative assumption that the borrower initially borrowed maxAmount from the original Vault. This potentially restricts refinances in cases where the borrower borrowed less than maxAmount, but does not affect the target Vault's funds.