### PR TITLE
add proxy admin address to assume list for fuzz testing"

### DIFF
--- a/src/LienToken.sol
+++ b/src/LienToken.sol
@@ -327,7 +327,7 @@ contract LienToken is ERC721, ILienToken, AuthInitializable, AmountDeriver {
         }
         uint256 allowedSpendForPayment = ERC20(stack.lien.token).allowance(
           address(s.COLLATERAL_TOKEN),
-          address(s.TRANSFER_PROXY)
+          address(s.ASTARIA_ROUTER.TRANSFER_PROXY())
         );
 
         uint256 owing = s

--- a/src/test/FuzzTesting.t.sol
+++ b/src/test/FuzzTesting.t.sol
@@ -148,6 +148,35 @@ contract AstariaFuzzTest is TestHelpers, SigUtils, Bound {
     }
 
     vm.assume(params.borrower != COLLATERAL_TOKEN.getConduit());
+    vm.assume(params.borrower != address(COLLATERAL_TOKEN));
+    vm.assume(params.borrower != address(MRA));
+    vm.assume(params.borrower != address(LIEN_TOKEN));
+    vm.assume(params.borrower != address(ASTARIA_ROUTER));
+    vm.assume(params.borrower != address(TRANSFER_PROXY));
+    vm.assume(params.borrower != address(vault));
+    vm.assume(params.borrower != address(test721_1));
+    vm.assume(params.borrower != address(test721_2));
+    vm.assume(params.borrower != address(test721_3));
+    vm.assume(params.borrower != address(token1));
+    vm.assume(params.borrower != address(token2));
+    vm.assume(params.borrower != address(token3));
+    vm.assume(params.borrower != address(consideration));
+    vm.assume(params.borrower != address(conduitController));
+    vm.assume(params.lender != COLLATERAL_TOKEN.getConduit());
+    vm.assume(params.lender != address(COLLATERAL_TOKEN));
+    vm.assume(params.lender != address(MRA));
+    vm.assume(params.lender != address(LIEN_TOKEN));
+    vm.assume(params.lender != address(ASTARIA_ROUTER));
+    vm.assume(params.lender != address(TRANSFER_PROXY));
+    vm.assume(params.lender != address(vault));
+    vm.assume(params.lender != address(test721_1));
+    vm.assume(params.lender != address(test721_2));
+    vm.assume(params.lender != address(test721_3));
+    vm.assume(params.lender != address(token1));
+    vm.assume(params.lender != address(token2));
+    vm.assume(params.lender != address(token3));
+    vm.assume(params.lender != address(consideration));
+    vm.assume(params.lender != address(conduitController));
     vm.assume(!willArithmeticOverflow(params, term));
 
     //BORROWER MINT & APPROVE NFT

--- a/src/test/FuzzTesting.t.sol
+++ b/src/test/FuzzTesting.t.sol
@@ -149,6 +149,7 @@ contract AstariaFuzzTest is TestHelpers, SigUtils, Bound {
 
     vm.assume(params.borrower != COLLATERAL_TOKEN.getConduit());
     vm.assume(params.borrower != address(COLLATERAL_TOKEN));
+    vm.assume(params.borrower != address(PROXY_ADMIN));
     vm.assume(params.borrower != address(MRA));
     vm.assume(params.borrower != address(LIEN_TOKEN));
     vm.assume(params.borrower != address(ASTARIA_ROUTER));
@@ -164,6 +165,7 @@ contract AstariaFuzzTest is TestHelpers, SigUtils, Bound {
     vm.assume(params.borrower != address(conduitController));
     vm.assume(params.lender != COLLATERAL_TOKEN.getConduit());
     vm.assume(params.lender != address(COLLATERAL_TOKEN));
+    vm.assume(params.lender != address(PROXY_ADMIN));
     vm.assume(params.lender != address(MRA));
     vm.assume(params.lender != address(LIEN_TOKEN));
     vm.assume(params.lender != address(ASTARIA_ROUTER));

--- a/src/test/FuzzTesting.t.sol
+++ b/src/test/FuzzTesting.t.sol
@@ -161,6 +161,7 @@ contract AstariaFuzzTest is TestHelpers, SigUtils, Bound {
     vm.stopPrank();
 
     //LEND
+    params.lender = _toAddress(_boundMin(_toUint(params.lender), 100));
     vm.deal(address(params.lender), term.maxAmount);
 
     vm.startPrank(address(params.lender));


### PR DESCRIPTION
- fixed fuzz lender address
- fix fuzz testing with strict assumes on borrower and lender, fix regression from PR#339
- ensure proxy admin is not apart of fuzz params for borrower or lender
