### PR TITLE
fix: Spearbit #77 donation amount to PublicVault

### DIFF
--- a/src/LienToken.sol
+++ b/src/LienToken.sol
@@ -427,6 +427,7 @@ contract LienToken is ERC721, ILienToken, AuthInitializable, AmountDeriver {
           decreaseInYIntercept: decreaseYIntercept, //if the lien owner is not the payee then we are not decreasing the y intercept
           interestPaid: interestPaid,
           decreaseInSlope: decreaseInSlope,
+          amount: amountOwed,
           lienEnd: end
         })
       );

--- a/src/PublicVault.sol
+++ b/src/PublicVault.sol
@@ -300,7 +300,7 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
       s.currentEpoch,
       s.withdrawReserve,
       s.liquidationWithdrawRatio,
-      s.strategistUnclaimedShares
+      s.balance
     );
   }
 
@@ -439,6 +439,7 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
 
       if (withdrawBalance > 0) {
         ERC20(asset()).safeTransfer(currentWithdrawProxy, withdrawBalance);
+        s.balance -= withdrawBalance;
         WithdrawProxy(currentWithdrawProxy).increaseWithdrawReserveReceived(
           withdrawBalance
         );
@@ -486,7 +487,13 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
           data,
           (address, uint256, uint40, uint256, address, uint256)
         );
-
+      VaultData storage s = _loadStorageSlot();
+      if (amount > s.balance) {
+        revert InvalidVaultState(
+          InvalidVaultStates.LOAN_GREATER_THAN_VIRTUAL_BALANCE
+        );
+      }
+      s.balance -= amount;
       _issuePayout(borrower, amount, feeTo, feeRake);
       _addLien(tokenId, lienSlope, lienEnd);
     }
@@ -551,11 +558,12 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
    * @param params The params to adjust things
    */
   function updateVault(UpdateVaultParams calldata params) external {
-    _onlyLienToken();
+    _onlyAuth();
 
     VaultData storage s = _loadStorageSlot();
     _accrue(s);
 
+    s.balance += params.amount;
     //we are a payment
     if (params.decreaseInSlope > 0) {
       uint256 newSlope = s.slope - params.decreaseInSlope;
@@ -566,6 +574,14 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
       _setYIntercept(s, s.yIntercept - params.decreaseInYIntercept);
     }
     _handleStrategistInterestReward(s, params.interestPaid);
+  }
+
+  function skim() external {
+    VaultData storage s = _loadStorageSlot();
+    uint256 skimAmount = ERC20(asset()).balanceOf(address(this)) - s.balance;
+    if (skimAmount > 0) {
+      _setYIntercept(s, s.yIntercept + skimAmount);
+    }
   }
 
   function _setSlope(VaultData storage s, uint256 newSlope) internal {
@@ -618,6 +634,7 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
 
     unchecked {
       s.yIntercept += assets;
+      s.balance += assets;
     }
     VIData storage v = _loadVISlot();
     if (v.depositCap != 0 && totalAssets() >= v.depositCap) {
@@ -695,36 +712,18 @@ contract PublicVault is VaultImplementation, IPublicVault, ERC4626Cloned {
     emit LienOpen(tokenId, epoch);
   }
 
-  /**
-   * @notice Increase the PublicVault yIntercept.
-   * @param amount newYIntercept The increase in yIntercept.
-   */
-  function increaseYIntercept(uint256 amount) public {
-    VaultData storage s = _loadStorageSlot();
-    uint64 currentEpoch = s.currentEpoch;
-    require(
-      currentEpoch != 0 &&
-        msg.sender == s.epochData[currentEpoch - 1].withdrawProxy
-    );
-    _setYIntercept(s, s.yIntercept + amount);
-  }
-
   function _onlyLienToken() internal view {
     require(msg.sender == address(ROUTER().LIEN_TOKEN()));
   }
 
-  /**
-   * @notice Decrease the PublicVault yIntercept.
-   * @param amount newYIntercept The decrease in yIntercept.
-   */
-  function decreaseYIntercept(uint256 amount) public {
+  function _onlyAuth() internal view {
     VaultData storage s = _loadStorageSlot();
     uint64 currentEpoch = s.currentEpoch;
     require(
-      currentEpoch != 0 &&
-        msg.sender == s.epochData[currentEpoch - 1].withdrawProxy
+      (currentEpoch != 0 &&
+        msg.sender == s.epochData[currentEpoch - 1].withdrawProxy) ||
+        msg.sender == address(ROUTER().LIEN_TOKEN())
     );
-    _setYIntercept(s, s.yIntercept - amount);
   }
 
   function _setYIntercept(VaultData storage s, uint256 newYIntercept) internal {

--- a/src/interfaces/IPublicVault.sol
+++ b/src/interfaces/IPublicVault.sol
@@ -32,7 +32,7 @@ interface IPublicVault is IVaultImplementation {
     uint64 currentEpoch;
     uint256 withdrawReserve;
     uint256 liquidationWithdrawRatio;
-    uint256 strategistUnclaimedShares;
+    uint256 balance;
     mapping(uint64 => EpochData) epochData;
   }
 
@@ -40,6 +40,7 @@ interface IPublicVault is IVaultImplementation {
     uint256 decreaseInSlope;
     uint256 interestPaid;
     uint256 decreaseInYIntercept;
+    uint256 amount;
     uint64 lienEnd;
   }
 
@@ -79,10 +80,6 @@ interface IPublicVault is IVaultImplementation {
 
   function processEpoch() external;
 
-  function increaseYIntercept(uint256 amount) external;
-
-  function decreaseYIntercept(uint256 amount) external;
-
   function getCurrentEpoch() external view returns (uint64);
 
   function timeToSecondEpochEnd() external view returns (uint256);
@@ -115,7 +112,8 @@ interface IPublicVault is IVaultImplementation {
     WITHDRAW_RESERVE_NOT_ZERO,
     LIENS_OPEN_FOR_EPOCH_NOT_ZERO,
     LIQUIDATION_ACCOUNTANT_ALREADY_DEPLOYED_FOR_EPOCH,
-    DEPOSIT_CAP_EXCEEDED
+    DEPOSIT_CAP_EXCEEDED,
+    LOAN_GREATER_THAN_VIRTUAL_BALANCE
   }
 
   event StrategistFee(uint256 feeInShares);


### PR DESCRIPTION
Adding a virtual balance to PublicVault, there is no clear way to determine between a balance received through a transfer vs a balance received through a deposit or repayment.

Before this the PR an amount could be borrowed from any balance available at the PublicVault. If that amount is liquidated and results in a decrease in the yIntercept it could underflow the yIntercept.

see: https://github.com/spearbit-audits/review-astaria2/issues/77 for more information